### PR TITLE
feat/SV-153: 즐겨찾기 전체조회 리스트 UI 구현

### DIFF
--- a/public/svgs/starIcon.svg
+++ b/public/svgs/starIcon.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800px" height="800px" viewBox="0 0 64 64" enable-background="new 0 0 64 64" xml:space="preserve" fill="#000000">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill="#ffc800" d="M62.799,23.737c-0.47-1.399-1.681-2.419-3.139-2.642l-16.969-2.593L35.069,2.265 C34.419,0.881,33.03,0,31.504,0c-1.527,0-2.915,0.881-3.565,2.265l-7.623,16.238L3.347,21.096c-1.458,0.223-2.669,1.242-3.138,2.642 c-0.469,1.4-0.115,2.942,0.916,4l12.392,12.707l-2.935,17.977c-0.242,1.488,0.389,2.984,1.62,3.854 c1.23,0.87,2.854,0.958,4.177,0.228l15.126-8.365l15.126,8.365c0.597,0.33,1.254,0.492,1.908,0.492c0.796,0,1.592-0.242,2.269-0.72 c1.231-0.869,1.861-2.365,1.619-3.854l-2.935-17.977l12.393-12.707C62.914,26.68,63.268,25.138,62.799,23.737z"/> </g>
+</svg>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -11,7 +11,7 @@ import SignUp from './pages/signUp';
 import Search from './pages/search';
 import TodayMungWrite from './pages/todaymungWrite';
 import TodayMungPlaceRegist from './pages/todaymungPlaceRegist';
-// import MyFavorite from './pages/myFavorite';
+import MyFavorite from './pages/myFavorite';
 import PlaceRecommend from './pages/recommend';
 import TodayMungDetail from './pages/todayMungDetail';
 import Mypage from './pages/my';
@@ -46,7 +46,7 @@ function Router() {
             element={<TodayMungPlaceRegist />}
           />
           <Route path={ROUTE.MY()} element={<Mypage/>} />
-          {/* <Route path={ROUTE.MYFAVORITE()} element={<MyFavorite/>} /> */}
+          <Route path={ROUTE.MYFAVORITE()} element={<MyFavorite/>} />
           <Route
             path={ROUTE.TODAYMUNG_DETAIL(':diaryId')}
             element={<TodayMungDetail />}

--- a/src/assets/images/svgs/StarIcon.tsx
+++ b/src/assets/images/svgs/StarIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+const SvgStarIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    xmlSpace="preserve"
+    viewBox="0 0 64 64"
+    {...props}
+  >
+    <path
+      fill="#ffc800"
+      d="M62.799 23.737a3.94 3.94 0 0 0-3.139-2.642l-16.969-2.593-7.622-16.237a3.938 3.938 0 0 0-7.13 0l-7.623 16.238-16.969 2.593a3.937 3.937 0 0 0-2.222 6.642l12.392 12.707-2.935 17.977a3.94 3.94 0 0 0 5.797 4.082l15.126-8.365 15.126 8.365a3.94 3.94 0 0 0 5.796-4.082l-2.935-17.977 12.393-12.707a3.94 3.94 0 0 0 .914-4.001"
+    />
+  </svg>
+);
+export default SvgStarIcon;

--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -11,10 +11,11 @@ import {
   UserEditIcon,
 } from '@/assets/images/svgs';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function Mypage() {
   const [editId, setEditId] = useState<number>(0);
-
+  const navigate = useNavigate();
   return (
     <S.Wrapper>
       <S.ProfileWrapper>
@@ -55,7 +56,7 @@ function Mypage() {
         </S.PetProfileWrapper>
       </S.ProfileWrapper>
       <S.ListWrapper>
-        <S.ListContainer>
+        <S.ListContainer onClick={() => navigate('/my/favorite')}>
           <HeartIcon width={19} height={19} />
           즐겨찾기 목록
         </S.ListContainer>

--- a/src/pages/myFavorite/constants/placeCategoryMapping.ts
+++ b/src/pages/myFavorite/constants/placeCategoryMapping.ts
@@ -1,0 +1,36 @@
+import { PlaceCategoryMappingType } from "../types/placeCategoryMappingType";
+
+export const PlaceCategoryMapping: PlaceCategoryMappingType = [
+  {
+    value: 'RESTAURANT',
+    label: '식당',
+  },
+  {
+    value: 'CAFE',
+    label: '카페',
+  },
+  {
+    value: 'PLAYGROUND',
+    label: '놀이터',
+  },
+  {
+    value: 'PARK',
+    label: '공원',
+  },
+  {
+    value: 'TRAVEL',
+    label: '여행지',
+  },
+  {
+    value: 'ACCOMMODATION',
+    label: '호텔',
+  },
+  {
+    value: 'MUSEUM',
+    label: '박물관',
+  },
+  {
+    value: 'GALLERY',
+    label: '미술관',
+  },
+];

--- a/src/pages/myFavorite/index.styles.ts
+++ b/src/pages/myFavorite/index.styles.ts
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+
+const S = {
+  Wrapper: styled.div`
+    width: 100%;
+    margin-top: 26px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  `,
+  CategoryWrapper: styled.div`
+    display: flex;
+    gap: 20px;
+    width: 100%;
+    overflow-x: scroll;
+    height: fit-content;
+    padding: 0 28px 0;
+  `,
+  CategoryContainer: styled.div<{ isActive: boolean }>`
+    padding: 10px 0;
+    font-size: 16px;
+    font-weight: 500;
+    color: #000;
+    cursor: pointer;
+    padding: 2px 2px 4px 2px;
+    border-bottom: ${({ isActive }) => (isActive ? '2px solid #000' : 'none')};
+    white-space: nowrap;
+  `,
+  PlaceWrapper: styled.div`
+    padding: 0 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 40px;
+    height: 100dvh;
+    overflow-y: scroll;
+    padding-bottom: 280px;
+  `,
+  PlaceCard: styled.div`
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 16px;
+    height: fit-content;
+    width: 100%;
+  `,
+  ImageWrapper: styled.div`
+    position: relative;
+    height: 100%;
+    border-radius: 5px;
+    box-sizing: border-box;
+  `,
+  PlaceImage: styled.img`
+    width: 115px;
+    height: 146px;
+    object-fit: cover;
+    box-sizing: border-box;
+    display: block;
+  `,
+  Like: styled.div`
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    z-index: 10;
+    cursor: pointer;
+  `,
+  PlaceInfo: styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: fit-content;
+    margin-top: 6px;
+  `,
+  PlaceLocation: styled.span`
+    font-size: 12px;
+    font-weight: 300;
+    color: #000;
+  `,
+  PlaceName: styled.span`
+    font-size: 16px;
+    font-weight: 700;
+    color: #000;
+    margin-top: 8px;
+  `,
+  ReviewWrapper: styled.div`
+    display: flex;
+    align-items: center;
+    margin-top: 10px;
+  `,
+  StarRating: styled.span`
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 16px;
+    letter-spacing: -0.08px;
+    color: #000;
+    margin-left: 4px;
+    margin-right: 10px;
+  `,
+  ReviewCount: styled.span`
+    color: #7d7d7d;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 16px; /* 133.333% */
+  `,
+};
+
+export default S;

--- a/src/pages/myFavorite/index.tsx
+++ b/src/pages/myFavorite/index.tsx
@@ -6,25 +6,36 @@ import { IoHeartSharp } from 'react-icons/io5';
 import { IoHeartOutline } from 'react-icons/io5';
 import { StarIcon } from '@/assets/images/svgs';
 import { PlaceCategoryMapping } from './constants/placeCategoryMapping';
+import { useNavigate } from 'react-router-dom';
+import { ROUTE } from '@/common/constants/route';
 
 function MyFavorite() {
   const [value, setValue] = useState<PlaceCategory>('RESTAURANT');
   const [isLikedId, setIsLikedId] = useState<number>(0);
+
+  const navigate = useNavigate();
+
   const parsedAddress = (address: string) => {
     const parsed = address.split(' ').slice(0, 2).join(' ');
     return parsed;
-  }
+  };
   const handleCategoryClick = (value: PlaceCategory) => {
     setValue(value);
   };
 
-  {/** @Todo API 부착 시, 해당 장소의 즐겨찾기 여부를 토글하도록 변경 */}
+  {
+    /** @Todo API 부착 시, 해당 장소의 즐겨찾기 여부를 토글하도록 변경 */
+  }
   const handleLikeClick = (id: number) => {
     if (isLikedId === id) {
       setIsLikedId(0);
     } else {
       setIsLikedId(id);
     }
+  };
+
+  const navigateToDetail = (placeId: number) => {
+    navigate(ROUTE.DETAIL(placeId));
   };
 
   return (
@@ -42,7 +53,10 @@ function MyFavorite() {
       </S.CategoryWrapper>
       <S.PlaceWrapper>
         {placeMap.map((place) => (
-          <S.PlaceCard key={place.place_id}>
+          <S.PlaceCard
+            onClick={() => navigateToDetail(place.place_id)}
+            key={place.place_id}
+          >
             <S.ImageWrapper>
               <S.PlaceImage src={place.place_img_url} alt={place.place_name} />
               {place.place_id === isLikedId ? (
@@ -56,10 +70,12 @@ function MyFavorite() {
               )}
             </S.ImageWrapper>
             <S.PlaceInfo>
-              <S.PlaceLocation>{parsedAddress(place.road_address)}</S.PlaceLocation>
+              <S.PlaceLocation>
+                {parsedAddress(place.road_address)}
+              </S.PlaceLocation>
               <S.PlaceName>{place.place_name}</S.PlaceName>
               <S.ReviewWrapper>
-                <StarIcon width={14} height={14}/>
+                <StarIcon width={14} height={14} />
                 <S.StarRating>{place.star_rating_avg}</S.StarRating>
                 <S.ReviewCount>리뷰 {place.review_count}</S.ReviewCount>
               </S.ReviewWrapper>

--- a/src/pages/myFavorite/index.tsx
+++ b/src/pages/myFavorite/index.tsx
@@ -1,0 +1,74 @@
+import { PlaceCategory } from '@/common/types';
+import S from './index.styles';
+import { useState } from 'react';
+import { placeMap } from '@/mocks/data/placeMap';
+import { IoHeartSharp } from 'react-icons/io5';
+import { IoHeartOutline } from 'react-icons/io5';
+import { StarIcon } from '@/assets/images/svgs';
+import { PlaceCategoryMapping } from './constants/placeCategoryMapping';
+
+function MyFavorite() {
+  const [value, setValue] = useState<PlaceCategory>('RESTAURANT');
+  const [isLikedId, setIsLikedId] = useState<number>(0);
+  const parsedAddress = (address: string) => {
+    const parsed = address.split(' ').slice(0, 2).join(' ');
+    return parsed;
+  }
+  const handleCategoryClick = (value: PlaceCategory) => {
+    setValue(value);
+  };
+
+  {/** @Todo API 부착 시, 해당 장소의 즐겨찾기 여부를 토글하도록 변경 */}
+  const handleLikeClick = (id: number) => {
+    if (isLikedId === id) {
+      setIsLikedId(0);
+    } else {
+      setIsLikedId(id);
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.CategoryWrapper>
+        {PlaceCategoryMapping.map((category) => (
+          <S.CategoryContainer
+            key={category.value}
+            isActive={value === category.value}
+            onClick={() => handleCategoryClick(category.value)}
+          >
+            {category.label}
+          </S.CategoryContainer>
+        ))}
+      </S.CategoryWrapper>
+      <S.PlaceWrapper>
+        {placeMap.map((place) => (
+          <S.PlaceCard key={place.place_id}>
+            <S.ImageWrapper>
+              <S.PlaceImage src={place.place_img_url} alt={place.place_name} />
+              {place.place_id === isLikedId ? (
+                <S.Like onClick={() => handleLikeClick(place.place_id)}>
+                  <IoHeartSharp size={24} color="#FF4E3E" />
+                </S.Like>
+              ) : (
+                <S.Like onClick={() => handleLikeClick(place.place_id)}>
+                  <IoHeartOutline size={24} color="#FF4E3E" />
+                </S.Like>
+              )}
+            </S.ImageWrapper>
+            <S.PlaceInfo>
+              <S.PlaceLocation>{parsedAddress(place.road_address)}</S.PlaceLocation>
+              <S.PlaceName>{place.place_name}</S.PlaceName>
+              <S.ReviewWrapper>
+                <StarIcon width={14} height={14}/>
+                <S.StarRating>{place.star_rating_avg}</S.StarRating>
+                <S.ReviewCount>리뷰 {place.review_count}</S.ReviewCount>
+              </S.ReviewWrapper>
+            </S.PlaceInfo>
+          </S.PlaceCard>
+        ))}
+      </S.PlaceWrapper>
+    </S.Wrapper>
+  );
+}
+
+export default MyFavorite;

--- a/src/pages/myFavorite/types/placeCategoryMappingType.ts
+++ b/src/pages/myFavorite/types/placeCategoryMappingType.ts
@@ -1,0 +1,6 @@
+import { PlaceCategory } from "@/common/types";
+
+export type PlaceCategoryMappingType = {
+  value: PlaceCategory;
+  label: string;
+}[];


### PR DESCRIPTION
## 📝 관련 이슈

- https://ureca7.atlassian.net/browse/SV-153

## 💻 작업 내용

- 즐거찾기 전체조회 리스트 UI 구현
- 기존의 장소 카테고리 타입과 한글 이름을 매핑하는 PlaceCategoryMappingType 추가
- 별 아이콘 svg 파일 추가

## 🙇 특이 사항

<img width="417" alt="image" src="https://github.com/user-attachments/assets/32d140fa-5978-4e49-9a66-206db0b89c8d">


- 현재 즐겨찾기 전체조회 mockData를 사용하는 것이 아닌, 장소 조회 mockData를 사용하고 있습니다.

## 👻 리뷰 요구사항 (선택)
- 

<br><br>
