### PR TITLE
feat/SV-313: 반려견length가 0이하면 조건부 렌더링

### DIFF
--- a/src/pages/todaymungDetail/index.tsx
+++ b/src/pages/todaymungDetail/index.tsx
@@ -32,7 +32,6 @@ const TodayMungDetail = () => {
   const handleToggleClick = () => {
     setEditToggle(!editToggle);
   };
-  console.log(diaryData);
   return (
     <S.Wrapper>
       <S.Container>
@@ -56,7 +55,7 @@ const TodayMungDetail = () => {
             </S.PlaceTagCardArea>
           </S.PlaceArea>
         )}
-        {diaryData.dogs && (
+        {diaryData.dogs && diaryData.dogs.length > 0 && (
           <S.DogsArea>
             <S.DogsAreaTitle>오늘을 함께한 반려견</S.DogsAreaTitle>
             <S.DogTagList>


### PR DESCRIPTION
## 📝 관련 이슈

- https://ureca7.atlassian.net/browse/SV-313

## 💻 작업 내용

- 기존에 반려견 같은 경우에는 데이터베이스에 오늘멍에 등록하는 반려견과 유저의 반려견이 외래키로 얽혀있어서 오늘멍디비에 a라는 강아지가 있으면 외래키를 참조하기 때문에 a라는 강아지를 삭제할 수가 없던 에러라 프론트에서의 수정보다는 희진님께서 API를 직접 수정해주셨습니다!
- 그래도 오늘멍에서 추억을 남기는건데 따로 테이블을 파서 강아지 이름은 남기면 좋지 않을까라는 생각...? 반려견에서 삭제했다고 오늘멍에서도 삭제되는게 조금 아쉽지 않을까 하는 생각이 들지만 마감기한도 코앞이고 그냥 그런 생각만 들었다 입니다 ! 
- diaryData.dogs.length <= 0 일 때 소제목도 안보이게 하기.

## 🙇 특이 사항

- gif, img 첨부(선택사항)
- 전
<img width="369" alt="image" src="https://github.com/user-attachments/assets/58c6746b-8c59-4790-802c-0a73604fc36c">

후
<img width="359" alt="image" src="https://github.com/user-attachments/assets/ce9825bb-bc46-41e4-a6f6-f6d1ea3c0dd4">


## 👻 리뷰 요구사항 (선택)
- 

<br><br>
