### PR TITLE
feat/SV-299: 검색창 onClick 이벤트 핸들러에 함수 전달 방식 변경

### DIFF
--- a/src/pages/todaymungPlaceRegist/index.tsx
+++ b/src/pages/todaymungPlaceRegist/index.tsx
@@ -69,6 +69,7 @@ function TodayMungPlaceRegist() {
     };
 
     setSearchHistory(updateSearchHistory(searchHistory, newSearchItem));
+
     setSearchKeyword(searchValue);
     navigate(ROUTE.TODAYMUNG_PLACE_REGIST() + '?search=' + searchValue);
   };
@@ -86,6 +87,7 @@ function TodayMungPlaceRegist() {
     setSearchHistory(clearSearchHistory());
     closeModal();
   };
+
   if (isLoading) return <LoadingSpinnerLottie />;
   if (error) return <div>에러 발생</div>;
 
@@ -125,7 +127,7 @@ function TodayMungPlaceRegist() {
           onChange={(e) => setSearchKeyword(e.target.value)}
           inputRef={inputRef}
           autofocus={true}
-          onClick={handleSearch}
+          onClick={() => handleSearch()}
         />
       </S.SearchInputWrapper>
 

--- a/src/pages/todaymungPlaceRegist/index.tsx
+++ b/src/pages/todaymungPlaceRegist/index.tsx
@@ -61,14 +61,15 @@ function TodayMungPlaceRegist() {
 
   const handleSearch = (searchKeyword?: string) => {
     const searchValue = searchKeyword || inputRef?.current?.value.trim();
+    console.log(searchValue, searchKeyword, inputRef?.current?.value.trim());
     if (!searchValue) return;
     const newSearchItem: SearchHistoryItem = {
       id: Date.now(),
       keyword: searchValue,
       createdAt: formatDate(new Date()),
     };
-
     setSearchHistory(updateSearchHistory(searchHistory, newSearchItem));
+
     setSearchKeyword(searchValue);
     navigate(ROUTE.TODAYMUNG_PLACE_REGIST() + '?search=' + searchValue);
   };
@@ -86,6 +87,7 @@ function TodayMungPlaceRegist() {
     setSearchHistory(clearSearchHistory());
     closeModal();
   };
+
   if (isLoading) return <LoadingSpinnerLottie />;
   if (error) return <div>에러 발생</div>;
 


### PR DESCRIPTION
## 📝 관련 이슈

- https://ureca7.atlassian.net/browse/SV-299

## 💻 작업 내용

- 오늘멍 장소등록 페이지에서 검색 아이콘을 클릭해도 검색이 안 됐었는데, 가능하도록 수정하였습니다.

### 버그 배경

handleSearch 함수는 searchKeyword를 선택적으로 매개변수로 받도록 정의되었습니다. 어차피 searchKeyword를 전달하지 못할 경우에도 inputRef를 통해 값을 가져올 수 있기 때문입니다.

```
const handleSearch = (searchKeyword?: string) => {
    const searchValue = searchKeyword || inputRef?.current?.value.trim();
    if (!searchValue) return;
    const newSearchItem: SearchHistoryItem = {
      id: Date.now(),
      keyword: searchValue,
      createdAt: formatDate(new Date()),
    };
    setSearchHistory(updateSearchHistory(searchHistory, newSearchItem));

    setSearchKeyword(searchValue);
    navigate(ROUTE.TODAYMUNG_PLACE_REGIST() + '?search=' + searchValue);
  };
  
  ```

따라서 엔터 키를 눌러 실행하거나 최근 검색어 키워드 클릭을 통해 handleSearch를 호출할 때는 searchKeyword가 매개변수로 전달되어 정상적으로 작동했습니다.

```
/** 최근 검색 키워드 클릭함수 */
 <S.TimeIconTextWrapper onClick={() => handleSearch(item.keyword)} >

```

하지만 아이콘 클릭 이벤트에서 handleSearch를 이렇게 호출했을 때 문제가 발생했습니다:

```
   <SearchInput
          value={searchKeyword}
          onChange={(e) => setSearchKeyword(e.target.value)}
          inputRef={inputRef}
          autofocus={true}
          **onClick={handleSearch}**
        />

```

### 원인
`onClick={handleSearch}`와 같이 함수 참조 방식으로 전달할 때 문제가 발생했습니다. 함수 참조 방식으로 함수를 이벤트 핸들러에 전달할 경우 React는 SyntheticEvent 객체를 자동으로 첫 번째 인자로 전달하기 때문에 발생한 문제였습니다.

<img width="340" alt="image" src="https://github.com/user-attachments/assets/8d35f09c-e1ad-47aa-ba63-c40849d1a00b" />


**SyntheticEvent?**
- React는 DOM 이벤트를 감싸는 SyntheticEvent 객체를 사용하여 이벤트 처리를 최적화하고 브라우저 간 호환성 문제를 해결합니다.
- onClick={handleSearch}와 같이 함수명을 직접 전달하면, React는 자동으로 이벤트 객체(SyntheticEvent)를 첫 번째 인자로 넘깁니다. 이 객체는 실제 DOM 이벤트(MouseEvent, KeyboardEvent 등)를 감싸고 있으며, React 특화 기능(stopPropagation, preventDefault 등)을 제공합니다.

즉, React는 이벤트가 발생하면 자동적으로 SyntheticEvent 객체를 전달합니다. 따라서 제가 처음에 작성한 코드인 ` onClick={handleSearch}` 처럼 함수 참조 방식으로 이벤트 핸들러에 함수를 직접 전달할 경우 명시적으로는 인자를 넘겨주지 않지만, 리액트에선 SyntheticEvent 객체를 전달하고 있었던 것이었습니다.

`const searchValue = searchKeyword || inputRef?.current?.value.trim();`

이로 인해 searchValue가 SyntheticEvent 객체로 설정되어, 이후 newSearchItem을 만드는 과정에서 잘못된 값이 들어가게 되었습니다.

### 해결 방법
onClick 함수를 함수 참조 방식으로 전달하지 않고, 래핑 함수 방식으로 전달할 경우 SyntheticEvent 객체를 전달하지 않기 때문에 해결할 수 있었습니다.


## 🙇 특이 사항

- gif, img 첨부(선택사항)
![feat:SV-299](https://github.com/user-attachments/assets/e5049f4a-b9bf-4105-8e39-c6794b918579)


## 👻 리뷰 요구사항 (선택)
- 

<br><br>
