### PR TITLE
fix/SV-368: 메인페이지 지도 height 조절

### DIFF
--- a/src/pages/main/styles/index.style.ts
+++ b/src/pages/main/styles/index.style.ts
@@ -1,3 +1,4 @@
+import { BOTTOM_NAV_HEIGHT } from '@/common/constants/ui';
 import styled from 'styled-components';
 
 const S = {
@@ -7,7 +8,7 @@ const S = {
 
   MapWrapper: styled.div`
     width: 100%;
-    flex: 1;
+    height: calc(100dvh - ${BOTTOM_NAV_HEIGHT});
   `,
 
   LocationButtonWrapper: styled.div<{ $bottomHeight: number }>`


### PR DESCRIPTION
## 📝 관련 이슈

- https://ureca7.atlassian.net/browse/SV-368

## 💻 작업 내용

- 메인페이지 지도의 height를 100dvh - bottom_nav_height로 설정하였습니다.

## 🙇 특이 사항

- gif, img 첨부(선택사항)


## 👻 리뷰 요구사항 (선택)
- 

<br><br>
